### PR TITLE
Adding initial commandline interface

### DIFF
--- a/cleanX/__main__.py
+++ b/cleanX/__main__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+from .cli import main
+
+
+main()

--- a/cleanX/cli/__init__.py
+++ b/cleanX/cli/__init__.py
@@ -81,7 +81,7 @@ def dicom(cfg):
     nargs=2,
     multiple=True,
     help='''
-    Repeatable.  Takes two arguments.  First argument is a type of source, 
+    Repeatable.  Takes two arguments.  First argument is a type of source,
     the second is the source description.
 
     Supported source types are:
@@ -90,11 +90,11 @@ def dicom(cfg):
     * dir
     * glob
 
-    If source type is `dir', then the source description must be a path 
+    If source type is `dir', then the source description must be a path
     to a directory.
 
-    If source type is `glob', then the source description must be a glob 
-    pattern as used by Python's builtin glob function.  Whether glob 
+    If source type is `glob', then the source description must be a glob
+    pattern as used by Python's builtin glob function.  Whether glob
     pattern will be interpreted as recursive is controlled by configuration
     setting GLOB_IS_RECURSIVE.
     ''',

--- a/cleanX/cli/__init__.py
+++ b/cleanX/cli/__init__.py
@@ -140,6 +140,34 @@ def dataset(cfg):
     ''',
 )
 @click.option(
+    '--report-duplicates/--no-report-duplicates',
+    default=True,
+    help='''
+    Whether the report should contain information about ducplicates.
+    ''',
+)
+@click.option(
+    '--report-leakage/--no-report-leakage',
+    default=True,
+    help='''
+    Whether the report should contain information about leakage.
+    ''',
+)
+@click.option(
+    '--report-bias/--no-report-bias',
+    default=True,
+    help='''
+    Whether the report should contain information about leakage.
+    ''',
+)
+@click.option(
+    '--report-understand/--no-report-understand',
+    default=True,
+    help='''
+    Whether the report should contain information about understanding.
+    ''',
+)
+@click.option(
     '-o',
     '--output',
     default=None,
@@ -160,6 +188,10 @@ def generate_report(
         label_tag,
         sensitive_category,
         output,
+        report_duplicates,
+        report_leakage,
+        report_bias,
+        report_understand,
 ):
     mlsetup = MLSetup(
         train_source,
@@ -168,7 +200,12 @@ def generate_report(
         label_tag=label_tag,
         sensitive_list=sensitive_category,
     )
-    report = mlsetup.generate_report()
+    report = mlsetup.generate_report(
+        duplicates=report_duplicates,
+        leakage=report_leakage,
+        bias=report_bias,
+        understand=report_understand,
+    )
     if output is None:
         print(report.to_text())
     else:

--- a/cleanX/cli/__init__.py
+++ b/cleanX/cli/__init__.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import copy
+
+from importlib import import_module
+from textwrap import dedent
+from pydoc import locate
+
+import click
+
+from cleanX.dicom_processing import (
+    DirectorySource,
+    GlobSource,
+    MultiSource,
+)
+
+
+class Config:
+
+    defaults = {
+        'PREFERRED_DICOM_PARSER': 'pydicom',
+        'GLOB_IS_RECURSIVE': True,
+    }
+
+    def __init__(self, source=None):
+        self.source = source
+        self.properties = {}
+        if self.source is not None:
+            self.parse()
+        else:
+            self.properties = copy.deepcopy(self.defaults)
+
+    def parse(self):
+        with open(self.source) as f:
+            self.properties = self.merge(self.defaults, json.read(f))
+
+    def merge(self, defaults, extras):
+        # TODO(wvxvw): smarter merging
+        copy = dict(defaults)
+        copy.update(extras)
+        return copy
+
+    def add_setting(self, k, v):
+        # TODO(wvxvw): hierarchical property names
+        self.properties = self.merge(self.properties, {k: v})
+
+    def get_setting(self, k):
+        # TODO(wvxvw): hierarchical property names
+        return self.properties[k]
+
+
+@click.group()
+@click.option('-c', '--config', nargs=2, multiple=True, default=[])
+@click.option('-f', '--config-file', default=None)
+@click.pass_context
+def main(ctx, config, config_file):
+    if config and config_file:
+        raise SystemExit(dedent(
+            '''
+            Must specify either configuration pairs, or configuration file
+            '''
+        ))
+    ctx.obj = Config(config_file)
+    for k, v in config:
+        ctx.obj.add_setting(k, v)
+
+
+@main.group()
+@click.pass_obj
+def dicom(cfg):
+    pass
+
+
+@dicom.command()
+@click.pass_obj
+@click.option(
+    '-i',
+    '--input',
+    nargs=2,
+    multiple=True,
+    help='''
+    Repeatable.  Takes two arguments.  First argument is a type of source, 
+    the second is the source description.
+
+    Supported source types are:
+
+    \b
+    * dir
+    * glob
+
+    If source type is `dir', then the source description must be a path 
+    to a directory.
+
+    If source type is `glob', then the source description must be a glob 
+    pattern as used by Python's builtin glob function.  Whether glob 
+    pattern will be interpreted as recursive is controlled by configuration
+    setting GLOB_IS_RECURSIVE.
+    ''',
+)
+@click.option(
+    '-o',
+    '--output',
+    default='.',
+    help='''
+    The directory where the extracted images will be placed.
+    ''',
+)
+@click.option(
+    '-c',
+    '--config-reader',
+    nargs=2,
+    multiple=True,
+    help='''
+    Options to pass to the DICOM reader at initialization time.
+
+    These will depend on the chosen reader.
+    '''
+)
+def extract_images(cfg, input, output, config_reader):
+    preferred_parser = cfg.get_setting('PREFERRED_DICOM_PARSER')
+    mod_name = 'cleanX.dicom_processing.'
+    class_name = 'DicomReader'
+
+    if preferred_parser == 'pydicom':
+        mod_name += 'pydicom_adapter'
+    else:
+        mod_name += 'simpleitk_adapter'
+    try:
+        dicom_mod = import_module(mod_name)
+    except ModuleNotFoundError:
+        try:
+            if preferred_parser == 'pydicom':
+                mod_name = mod_name.replace('pydicom', 'simpleitk')
+            else:
+                mod_name = mod_name.replace('simpleitk', 'pydicom')
+            dicom_mod = import_module(mod_name)
+        except ModuleNotFoundError:
+            raise SystemExit(dedent(
+                '''
+                Neither pydicom nor SimpleITK is available
+                '''
+            ))
+    if 'pydicom' in mod_name:
+        class_name = 'Pydicom' + class_name
+    else:
+        class_name = 'SimpleITK' + class_name
+    reader_class = getattr(dicom_mod, class_name)
+    reader_args = {
+        k: parse_reader_arg(k, v, dicom_mod)
+        for k, v in config_reader
+    }
+    reader = reader_class(**reader_args)
+    df = reader.read(parse_sources(input, cfg))
+    df.to_csv(os.path.join(output, 'report.csv'))
+
+
+def pydicom_str_to_type(raw, module):
+    try:
+        return getattr(module, raw)
+    except Exception:
+        return locate(raw)
+
+
+pydicom_reader_args = {
+    'exclude_field_types': [pydicom_str_to_type],
+    'date_fields': [str],
+    'time_fields': [str],
+    'exclude_fields': [str],
+}
+
+simpleitk_reader_args = {}
+
+
+def parse_reader_val_list(parser, value):
+    return [
+        parse_reader_val(parser, v)
+        for v in value
+    ]
+
+
+def parse_reader_val_dict(k, v, value):
+    return {
+        parse_reader_val(k, vk): parse_reader_val(v, vv)
+        for vk, vv in value.items()
+    }
+
+
+def parse_reader_val(parser, value):
+    if parser is list:
+        return parse_reader_val_list(parser[0], value)
+    if parser is dict:
+        for k, v in parser.items():
+            return parse_reader_val_dict(k, v, value)
+    return parser(value)
+
+
+def parse_reader_arg(name, value, module):
+    if module.__name__ == 'pydicom_adapter':
+        args = pydicom_reader_args
+    else:
+        args = simpleitk_reader_args
+    parser = args[name]
+    return parse_reader_val(parser, json.loads(value))
+
+
+def parse_sources(sources, cfg):
+    raw_result = []
+    for st, sv in sources:
+        if st == 'dir':
+            raw_result.append(DirectorySource(sv, ''))
+        elif st == 'glob':
+            raw_result.append(GlobSource(sv, ''))
+        else:
+            raise LookupError('Unsupported source type: {}'.format(st))
+    return MultiSource('source', *raw_result)

--- a/cleanX/dataset_processing/dataframes.py
+++ b/cleanX/dataset_processing/dataframes.py
@@ -377,8 +377,6 @@ class Report:
         return HTML(''.join(elements))
 
     def to_text(self):
-        # from IPython.display import HTML
-
         elements = []
         for k, v in self.sections.items():
             if type(v) is dict:

--- a/cleanX/dicom_processing/source.py
+++ b/cleanX/dicom_processing/source.py
@@ -84,15 +84,16 @@ class DirectorySource:
 class GlobSource:
     """Class to aid finding files from path (for later reading out DICOM)"""
 
-    def __init__(self, exp, tag):
+    def __init__(self, exp, tag, recursive=True):
         self.exp = exp
         self.tag = tag
+        self.recursive = recursive
 
     def get_tag(self):
         return self.tag
 
     def items(self, reader, transformer=None):
-        for file in glob(self.exp):
+        for file in glob(self.exp, recursive=self.recursive):
             parsed = reader(file)
             if transformer is not None:
                 full_path = transformer(file)

--- a/setup.py
+++ b/setup.py
@@ -291,6 +291,7 @@ setup(
         'cleanX.dataset_processing',
         'cleanX.dicom_processing',
         'cleanX.image_work',
+        'cleanX.cli',
     ],
     cmdclass={
         'test': PyTest,

--- a/setup.py
+++ b/setup.py
@@ -312,5 +312,10 @@ setup(
     },
     setup_requires=['sphinx'],
     install_requires=install_requires(),
+    extras_require={
+        'cli': ['click'],
+        'pydicom': ['pydicom'],
+        'simpleitk': ['SimpleITK'],
+    },
     zip_safe=False,
 )

--- a/test/test_cleanx.py
+++ b/test/test_cleanx.py
@@ -3,6 +3,7 @@
 import os
 import csv
 import json
+import subprocess
 
 from functools import partial
 from tempfile import TemporaryDirectory
@@ -430,3 +431,24 @@ def test_dataset_creation():
         assert len(m2) == common
         all_df = setup.concat_dataframe()
         assert len(m1) == len(all_df.columns)
+
+
+@pytest.mark.skipif(pydicom_missing() , reason="no pydicom available")
+def test_cli_pydicom():
+    dicomfile_directory1 = os.path.join(
+        os.path.dirname(__file__),
+        'dicom_example_folder',
+    )
+    with TemporaryDirectory() as td:
+        result = subprocess.call(
+            [
+                'python', '-m', 'cleanX',
+                'dicom', 'extract-images',
+                '-i', 'dir', dicomfile_directory1,
+                '-o', td,
+            ]
+        )
+        assert not result
+        df = pd.read_csv(os.path.join(td, 'report.csv'))
+        assert 'source' in df.columns
+        assert len(os.listdir(dicomfile_directory1)) == len(df)


### PR DESCRIPTION
@drcandacemakedamoore please review.

This doesn't cover the main body of work, the `image_work` module, but the other two should be covered.

Some examples of command-line usage look like this:

``` sh
python -m cleanX dataset generate-report \
    -r ./workflow_demo/example_csv.csv \
    -t ./workflow_demo/example_csv.csv \
    --no-report-leakage \
    --no-report-bias
```

or

``` sh
python -m cleanX dicom extract-images \
    -i dir ./test/dicom_example_folder \
    -o /tmp/converted-images
```